### PR TITLE
Update elasticsearch15.rb

### DIFF
--- a/elasticsearch15.rb
+++ b/elasticsearch15.rb
@@ -65,7 +65,7 @@ class Elasticsearch15 < Formula
     ln_s etc/"elasticsearch", prefix/"config"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Data:    #{var}/elasticsearch/#{cluster_name}/
     Logs:    #{var}/log/elasticsearch/#{cluster_name}.log
     Plugins: #{var}/lib/elasticsearch/plugins/
@@ -75,7 +75,7 @@ class Elasticsearch15 < Formula
 
   plist_options :manual => "elasticsearch --config=#{HOMEBREW_PREFIX}/opt/elasticsearch15/config/elasticsearch.yml"
 
-  def plist; <<-EOS.undent
+  def plist; <<~EOS
       <?xml version="1.0" encoding="UTF-8"?>
       <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
       <plist version="1.0">


### PR DESCRIPTION
Addresses the following warning:
```
Warning: Calling <<-EOS.undent is deprecated!
Use <<~EOS instead.
/usr/local/Homebrew/Library/Taps/customink/homebrew-elasticsearch15/elasticsearch15.rb:73:in `caveats'
Please report this to the customink/elasticsearch15 tap!
```